### PR TITLE
Feature KAN-62, KAN-64, refactor(account): Add adapter & i18n for company social status

### DIFF
--- a/src/__tests__/pages/Account.test.tsx
+++ b/src/__tests__/pages/Account.test.tsx
@@ -1,0 +1,167 @@
+// src/__tests__/pages/Account.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Account from '../../../pages/Account';
+import { AdaptedCompanySocialStatus } from '../../../models/social.model';
+import { User } from '../../../models/user.model';
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key, // Mock t function to return the key itself
+  }),
+}));
+
+// Mock AuthenticatedNavbar
+vi.mock('../../../components/navbar/AuthenticatedNavbar', () => ({
+  default: () => <div data-testid="mocked-navbar">Mocked Navbar</div>,
+}));
+
+// Mock useGetAccount hook
+const mockUseGetAccountDefault = vi.fn();
+vi.mock('../../../hooks/queries/user/useProfileQuery', () => ({
+  useGetAccount: () => mockUseGetAccountDefault(),
+}));
+
+// Mock useCompanySocialStatus hook
+const mockUseCompanySocialStatusDefault = vi.fn();
+vi.mock('../../../hooks/queries/user/useCompanySocialStatusQuery', () => ({
+  useCompanySocialStatus: () => mockUseCompanySocialStatusDefault(),
+}));
+
+// Mock createUserAdapter
+const mockUserAdapterFn = vi.fn();
+vi.mock('../../../adapters/user.adapter', () => ({
+  createUserAdapter: mockUserAdapterFn,
+}));
+
+// const mockSuccessStatusInstance: StatusSuccess = { code: 200, message: "Success" }; // No longer needed
+
+describe('Account Component', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    mockUseGetAccountDefault.mockReturnValue({
+      data: {
+        user: { id: '1', username: 'testuser', email: 'test@example.com' } as User
+      },
+      isLoading: false,
+      isError: false,
+    });
+    mockUserAdapterFn.mockImplementation((user: User) => user);
+  });
+
+  it('should display skeletons when social status is loading', () => {
+    mockUseCompanySocialStatusDefault.mockReturnValue({
+      data: null,
+      isLoading: true,
+      isError: false,
+      error: null,
+    });
+    render(<Account />);
+    expect(screen.getByText('account.socialStatus.title')).toBeInTheDocument();
+    const skeletons = screen.getAllByRole('progressbar');
+    expect(skeletons.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('should display specific error message if fetching social status fails and message exists', () => {
+    mockUseCompanySocialStatusDefault.mockReturnValue({
+      data: null, isLoading: false, isError: true, error: { message: 'Custom API error' },
+    });
+    render(<Account />);
+    expect(screen.getByText('account.socialStatus.title')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('Custom API error');
+  });
+
+  it('should display default translated error message if fetching social status fails and no message exists', () => {
+    mockUseCompanySocialStatusDefault.mockReturnValue({
+      data: null, isLoading: false, isError: true, error: { message: null },
+    });
+    render(<Account />);
+    expect(screen.getByText('account.socialStatus.title')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('account.socialStatus.errorLoad');
+  });
+
+  it('should display "account.socialStatus.noAccountsConfigured" when networks array is empty', () => {
+    mockUseCompanySocialStatusDefault.mockReturnValue({
+      data: { networks: [] } as AdaptedCompanySocialStatus,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    render(<Account />);
+    expect(screen.getByText('account.socialStatus.title')).toBeInTheDocument();
+    expect(screen.getByText('account.socialStatus.noAccountsConfigured')).toBeInTheDocument();
+  });
+
+  it('should display "account.socialStatus.unavailable" when socialStatusData is null', () => {
+    mockUseCompanySocialStatusDefault.mockReturnValue({
+      data: null, // Hook returns null
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    render(<Account />);
+    expect(screen.getByText('account.socialStatus.title')).toBeInTheDocument();
+    expect(screen.getByText('account.socialStatus.unavailable')).toBeInTheDocument();
+  });
+
+  it('should display social network status correctly (Twitter with credentials)', () => {
+    mockUseCompanySocialStatusDefault.mockReturnValue({
+      data: {
+        networks: [{ name: 'Twitter', hasCredentials: true }],
+      } as AdaptedCompanySocialStatus,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    render(<Account />);
+    expect(screen.getByText('account.socialStatus.title')).toBeInTheDocument();
+    const twitterCheckbox = screen.getByLabelText('Twitter'); // Label is 'Twitter' due to adapter
+    expect(twitterCheckbox).toBeInTheDocument();
+    expect(twitterCheckbox).toBeDisabled();
+    expect(twitterCheckbox).toBeChecked();
+  });
+
+  it('should display social network status correctly (Twitter without credentials)', () => {
+    mockUseCompanySocialStatusDefault.mockReturnValue({
+      data: {
+        networks: [{ name: 'Twitter', hasCredentials: false }],
+      } as AdaptedCompanySocialStatus,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+    render(<Account />);
+    expect(screen.getByText('account.socialStatus.title')).toBeInTheDocument();
+    const twitterCheckbox = screen.getByLabelText('Twitter');
+    expect(twitterCheckbox).toBeInTheDocument();
+    expect(twitterCheckbox).toBeDisabled();
+    expect(twitterCheckbox).not.toBeChecked();
+  });
+
+  it('should display basic user information correctly', () => {
+    const specificUser = { id: '2', username: 'janedoe', email: 'jane@example.com' } as User;
+    mockUseGetAccountDefault.mockReturnValue({
+      data: { user: specificUser },
+      isLoading: false,
+      isError: false,
+    });
+    mockUserAdapterFn.mockImplementationOnce((user: User) => ({ // mockImplementationOnce for specific test behavior
+        id: user.id,
+        username: `Adapted ${user.username}`, // Ensure this matches what you expect
+        email: user.email
+    }));
+    // Provide a default successful state for social status for this test too
+    mockUseCompanySocialStatusDefault.mockReturnValue({
+      data: { networks: [] } as AdaptedCompanySocialStatus,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(<Account />);
+    expect(screen.getByText('Adapted janedoe')).toBeInTheDocument();
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+  });
+});

--- a/src/_i18n/en.json
+++ b/src/_i18n/en.json
@@ -39,5 +39,14 @@
   "post.form.label.tags": "Tags",
   "post.form.label.date": "Publish Date",
   "posts.form.label.search": "Search by Title",
-  "posts.form.btn_search": "Search"
+  "posts.form.btn_search": "Search",
+
+  "account": {
+    "socialStatus": {
+      "title": "Company Social Networks",
+      "errorLoad": "Failed to load company social network status.",
+      "noAccountsConfigured": "No social network accounts configured.",
+      "unavailable": "Social network information is currently unavailable."
+    }
+  }
 }

--- a/src/_i18n/es.json
+++ b/src/_i18n/es.json
@@ -39,5 +39,14 @@
   "post.form.label.date": "Fecha de publicación",
   "post.form.label.btn.image": "Subir imagen",
   "posts.form.label.search": "Buscar port Titulo",
-  "posts.form.btn_search": "Buscar"
+  "posts.form.btn_search": "Buscar",
+
+  "account": {
+    "socialStatus": {
+      "title": "Redes Sociales de la Empresa",
+      "errorLoad": "Error al cargar el estado de las redes sociales de la empresa.",
+      "noAccountsConfigured": "No hay cuentas de redes sociales configuradas.",
+      "unavailable": "La información de las redes sociales no está disponible actualmente."
+    }
+  }
 }

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,3 +1,4 @@
 export * from './user.adapter.ts';
 export * from './post.adapter.ts';
 export * from './strategy.adapter.ts';
+export * from './social.adapter.ts';

--- a/src/adapters/social.adapter.ts
+++ b/src/adapters/social.adapter.ts
@@ -1,0 +1,21 @@
+import { CompanySocialStatusResponseUpdated, AdaptedCompanySocialStatus, AdaptedSocialNetworkEntry, SocialNetworkProviders } from '@models/social.model'; // Assuming CompanySocialStatusResponseUpdated is also in social.model or adjust import
+
+export const createCompanySocialStatusAdapter = (
+  apiResponse: CompanySocialStatusResponseUpdated | null | undefined
+): AdaptedCompanySocialStatus => {
+  if (!apiResponse || !apiResponse.social_networks) {
+    return { networks: [] }; // Return empty array if no data
+  }
+
+  const socialNetworksData = apiResponse.social_networks as SocialNetworkProviders;
+  const adaptedNetworks: AdaptedSocialNetworkEntry[] = Object.entries(socialNetworksData)
+    .map(([key, value]) => ({
+      name: key.charAt(0).toUpperCase() + key.slice(1), // Capitalize the network name
+      hasCredentials: value.has_credentials,
+      // key: key, // Optionally include the original key
+    }));
+
+  return {
+    networks: adaptedNetworks,
+  };
+};

--- a/src/hooks/queries/user/useCompanySocialStatusQuery.ts
+++ b/src/hooks/queries/user/useCompanySocialStatusQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { userService } from '@services/user.service';
+import { AdaptedCompanySocialStatus, CompanySocialStatusResponseUpdated } from '@models/social.model';
+import { USER_QUERY_KEYS } from '@utils/constants/user.constants';
+import { Error } from '@models/error.model';
+import { createCompanySocialStatusAdapter } from '@adapters/social.adapter';
+
+export const useCompanySocialStatus = (): UseQueryResult<AdaptedCompanySocialStatus, Error> => {
+  return useQuery<AdaptedCompanySocialStatus, Error, AdaptedCompanySocialStatus, string[]>({
+    queryKey: [USER_QUERY_KEYS.COMPANY_SOCIAL_STATUS],
+    queryFn: async () => {
+      const response = await userService.getCompanySocialStatus().call;
+      const rawData = response.data as CompanySocialStatusResponseUpdated;
+      return createCompanySocialStatusAdapter(rawData);
+    },
+    // Add any default options like staleTime, cacheTime if common in the project
+  });
+};

--- a/src/models/api.model.ts
+++ b/src/models/api.model.ts
@@ -22,3 +22,8 @@ export interface ParamsAxios {
 export interface ResponseAxiosService {
   call: Promise<AxiosResponse>;
 }
+
+export interface StatusSuccess {
+  code: number;
+  message: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -4,3 +4,4 @@ export * from './error.model.ts';
 export * from './post.model.ts';
 export * from './zustand.model.ts';
 export * from './strategy.model.ts';
+export * from './social.model.ts';

--- a/src/models/social.model.ts
+++ b/src/models/social.model.ts
@@ -1,0 +1,44 @@
+import { StatusSuccess } from './api.model'; // Assuming StatusSuccess is already defined
+
+export interface TwitterStatus {
+  has_credentials: boolean;
+}
+
+export interface SocialNetworks {
+  twitter: TwitterStatus;
+  // Add other social networks here if they become available in the API
+  // e.g., facebook?: FacebookStatus;
+}
+
+export interface CompanySocialStatusResponse {
+  status: StatusSuccess;
+  social_networks: SocialNetworks;
+}
+
+// It might also be useful to have a more generic type for individual social network status
+export interface SocialNetworkCredentialStatus {
+  has_credentials: boolean;
+}
+
+// And a type for the social_networks object that can be indexed by string
+export interface SocialNetworkProviders {
+  [key: string]: SocialNetworkCredentialStatus;
+}
+
+// Update CompanySocialStatusResponse to use SocialNetworkProviders
+export interface CompanySocialStatusResponseUpdated {
+  status: StatusSuccess;
+  social_networks: SocialNetworkProviders;
+}
+
+// New interfaces for adapted data
+export interface AdaptedSocialNetworkEntry {
+  name: string; // e.g., "Twitter"
+  hasCredentials: boolean;
+  // key: string; // keep original key for reference if needed e.g. for test ids
+}
+
+export interface AdaptedCompanySocialStatus {
+  networks: AdaptedSocialNetworkEntry[];
+  // Add other top-level properties here if the adapter introduces them
+}

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -17,6 +17,12 @@ const postLogin = ({ configService = { version: 'v1' }, data = {} }: ParamsAxios
   };
 };
 
+const getCompanySocialStatus = ({ configService = { version: 'v1' } }: ParamsAxios = {}): ResponseAxiosService => {
+  return {
+    call: apiClient().get(`/${configService?.version}/${USER_SERVICE}/me/company_social_status`),
+  };
+};
+
 const getUser = ({ configService = { version: 'v1' } }: ParamsAxios = {}): ResponseAxiosService => {
   return {
     call: apiClient().get(`/${configService?.version}/${USER_SERVICE}/me`),
@@ -41,4 +47,5 @@ export const userService = {
   getUser,
   deleteLogout,
   postSignUp,
+  getCompanySocialStatus,
 };

--- a/src/utils/constants/user.constants.ts
+++ b/src/utils/constants/user.constants.ts
@@ -13,3 +13,8 @@ export const initialValuesLogin: LoginFormErrorValues = {
   nickname: '',
   passwd: '',
 };
+
+export const USER_QUERY_KEYS = {
+  PROFILE: 'profile', // Example, if useGetAccount uses something like this
+  COMPANY_SOCIAL_STATUS: 'companySocialStatus',
+};


### PR DESCRIPTION
Refactored the company social network status feature on the Account page:

- I introduced an adapter (`createCompanySocialStatusAdapter`) to transform the raw API response for `/me/company_social_status` into a structured format (`AdaptedCompanySocialStatus`) for component consumption.
- The `useCompanySocialStatus` hook now utilizes this adapter to provide the transformed data to the Account component.
- The Account component is updated to use this adapted data structure, simplifying its rendering logic.
- I added internationalization (i18n) for all new user-facing strings in this section (title, error messages, empty states) using `react-i18next`. Translation keys are added to `en.json` and `es.json`.
- I updated unit tests for the Account component to:
    - Mock `react-i18next` and test for translation keys.
    - Reflect the new data structure returned by the (mocked) `useCompanySocialStatus` hook.
    - Ensure continued coverage for loading, error, empty, and data states.

This change improves code structure, maintainability, and provides a localized user experience.